### PR TITLE
Reduce time waiting for server to start

### DIFF
--- a/lib/quartz/go_process.rb
+++ b/lib/quartz/go_process.rb
@@ -42,13 +42,13 @@ class Quartz::GoProcess
   end
 
   def block_until_server_starts
-    max_retries = 10
+    max_retries = 7 # for delay of 0.005 it's about 7,69 sec
     retries = 0
     delay = 0.005 # seconds
 
     loop do
-      raise Quartz::GoServerError, 'RPC server not starting' if retries > max_retries
       return if File.exists?(@socket_path)
+      raise Quartz::GoServerError, 'RPC server not starting' if retries > max_retries
       sleep(delay * retries * 2**retries)
       retries += 1
     end

--- a/lib/quartz/go_process.rb
+++ b/lib/quartz/go_process.rb
@@ -42,9 +42,9 @@ class Quartz::GoProcess
   end
 
   def block_until_server_starts
-    max_retries = 7 # for delay of 0.005 it's about 7,69 sec
+    max_retries = 67 # for delay of 0.001 it's about 102.374 sec
     retries = 0
-    delay = 0.005 # seconds
+    delay = 0.001 # seconds
 
     loop do
       return if File.exists?(@socket_path)

--- a/lib/quartz/go_process.rb
+++ b/lib/quartz/go_process.rb
@@ -44,7 +44,7 @@ class Quartz::GoProcess
   def block_until_server_starts
     max_retries = 10
     retries = 0
-    delay = 0.1 # seconds
+    delay = 0.005 # seconds
 
     loop do
       raise Quartz::GoServerError, 'RPC server not starting' if retries > max_retries


### PR DESCRIPTION
On my machine this change makes the waiting time to be 0.012 sec instead of 0.205

Any reason to avoid the extra sleep calls?