### PR TITLE
[WIP] Pass the socket path as a command line argument

### DIFF
--- a/go/quartz/public.go
+++ b/go/quartz/public.go
@@ -9,5 +9,5 @@ func RegisterName(name string, s interface{}) error {
 }
 
 func Start(socketPath string) {
-	quartz.Start()
+	quartz.Start(socketPath)
 }

--- a/go/quartz/public.go
+++ b/go/quartz/public.go
@@ -8,6 +8,6 @@ func RegisterName(name string, s interface{}) error {
 	return quartz.RegisterName(name, s)
 }
 
-func Start() {
+func Start(socketPath string) {
 	quartz.Start()
 }

--- a/go/quartz/quartz.go
+++ b/go/quartz/quartz.go
@@ -36,13 +36,7 @@ func (q *Quartz) RegisterName(name string, s interface{}) error {
 	return rpc.RegisterName(name, s)
 }
 
-func (q *Quartz) Start() {
-	// The Ruby gem sets this environment variable for us.
-	socketPath := "/tmp/quartz.socket"
-	if os.Getenv("QUARTZ_SOCKET") != "" {
-		socketPath = os.Getenv("QUARTZ_SOCKET")
-	}
-
+func (q *Quartz) Start(socketPath string) {
 	// Start the server and accept connections on a
 	// UNIX domain socket.
 	rpc.RegisterName("Quartz", q.Registry)

--- a/lib/quartz/go_process.rb
+++ b/lib/quartz/go_process.rb
@@ -9,12 +9,11 @@ class Quartz::GoProcess
   def initialize(opts)
     @seed = SecureRandom.hex
     @socket_path = "/tmp/quartz_#{seed}.sock"
-    ENV['QUARTZ_SOCKET'] = @socket_path
 
     if opts[:file_path]
       compile_and_run(opts[:file_path])
     elsif opts[:bin_path]
-      @go_process = IO.popen(opts[:bin_path])
+      @go_process = IO.popen([opts[:bin_path], socket_path])
     else
       raise Quartz::ConfigError, 'Missing go binary'
     end
@@ -30,7 +29,7 @@ class Quartz::GoProcess
       raise Quartz::ConfigError, 'Go compilation failed'
     end
 
-    @go_process = IO.popen(@temp_file_path)
+    @go_process = IO.popen([@temp_file_path, socket_path])
   end
 
   def pid

--- a/spec/test.go
+++ b/spec/test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"os"
 
 	"github.com/DavidHuie/quartz/go/quartz"
 )
@@ -27,7 +28,9 @@ func (t *Test) AddError(args Args, response *Response) error {
 }
 
 func main() {
+	socket_path := os.Args[1]
+
 	a := &Test{}
 	quartz.RegisterName("adder", a)
-	quartz.Start()
+	quartz.Start(socket_path)
 }


### PR DESCRIPTION
This seems to be a safer approach for passing the socket_path to the server.

I can see issues by using environment variables if using threads for example:

```
10.times.map do
   Thread.new { Quartz::Client.new(file_path: 'spec/test.go')[:adder].call() }
end.each(&:join)
```

There is a chance that some of the servers will use the same socket file.
