### PR TITLE
Add option to specify the directory of the socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ client[:my_adder].call('Add', 'A' => 2, 'B' => 5)
 => { 'Sum' => 7 }
 ```
 
+By default the unix socket is created under `/tmp`. If you want to change that
+you can pass the `socket_dir` option.
+
+
+```ruby
+client = Quartz::Client.new(bin_path: 'my_adder_binary', socket_dir: '/apps/my_app/tmp')
+```
+
 ## Copyright
 
 Copyright (c) 2014 David Huie. See LICENSE.txt for further details.

--- a/lib/quartz/go_process.rb
+++ b/lib/quartz/go_process.rb
@@ -10,7 +10,8 @@ class Quartz::GoProcess
 
   def initialize(opts)
     @seed = SecureRandom.hex
-    @socket_path = "/tmp/quartz_#{seed}.sock"
+    socket_dir = opts.fetch(:socket_dir) { '/tmp' }
+    @socket_path = File.join(socket_dir, "quartz_#{seed}.sock")
     ENV['QUARTZ_SOCKET'] = @socket_path
 
     if opts[:file_path]

--- a/spec/go_process_spec.rb
+++ b/spec/go_process_spec.rb
@@ -34,6 +34,25 @@ describe Quartz::GoProcess do
     File.delete(temp_file)
   end
 
+  context 'when custom socket directory is used' do
+
+    before { Dir.mkdir(socket_dir) unless File.directory?(socket_dir) }
+
+    let(:socket_dir) { '/tmp/x' }
+    let(:process) { Quartz::GoProcess.new(file_path: 'spec/test.go', socket_dir: socket_dir) }
+
+    it 'works with custom socket directory' do
+      expect(File.exists?(process.socket_path)).to be_truthy
+      process.cleanup
+      expect(File.exists?(process.socket_path)).to be_falsey
+    end
+
+    it 'creates the socket in the socket dir' do
+      expect(process.socket_path).to match(/^#{socket_dir}\/quartz_[a-f\d]+\.sock/)
+    end
+
+  end
+
   describe '.cleanup' do
 
     context 'files' do


### PR DESCRIPTION
Because in most environment the `/tmp` folder is world readable and writable, it is safer to create the sockets in a different more private location.

By default the unix socket is created under `/tmp`. If you want to change that you can pass the `socket_dir` option.

```ruby
client = Quartz::Client.new(bin_path: 'my_adder_binary', socket_dir: '/apps/my_app/tmp')
```
